### PR TITLE
Fixed *string_copy_to_integer() converting invalid decimal strings

### DIFF
--- a/libfvalue/libfvalue_integer.c
+++ b/libfvalue/libfvalue_integer.c
@@ -1515,7 +1515,7 @@ int libfvalue_utf8_string_with_index_copy_to_integer(
 			value_64bit *= 10;
 
 			if( ( utf8_string[ string_index ] < (uint8_t) '0' )
-			 && ( utf8_string[ string_index ] > (uint8_t) '9' ) )
+			 || ( utf8_string[ string_index ] > (uint8_t) '9' ) )
 			{
 				libcerror_error_set(
 				 error,
@@ -2171,7 +2171,7 @@ int libfvalue_utf16_string_with_index_copy_to_integer(
 			value_64bit *= 10;
 
 			if( ( utf16_string[ string_index ] < (uint16_t) '0' )
-			 && ( utf16_string[ string_index ] > (uint16_t) '9' ) )
+			 || ( utf16_string[ string_index ] > (uint16_t) '9' ) )
 			{
 				libcerror_error_set(
 				 error,
@@ -2827,7 +2827,7 @@ int libfvalue_utf32_string_with_index_copy_to_integer(
 			value_64bit *= 10;
 
 			if( ( utf32_string[ string_index ] < (uint32_t) '0' )
-			 && ( utf32_string[ string_index ] > (uint32_t) '9' ) )
+			 || ( utf32_string[ string_index ] > (uint32_t) '9' ) )
 			{
 				libcerror_error_set(
 				 error,

--- a/tests/fvalue_test_integer.c
+++ b/tests/fvalue_test_integer.c
@@ -416,6 +416,213 @@ on_error:
 	return( 0 );
 }
 
+/* Tests the libfvalue_utf8_string_copy_to_integer function
+ * Returns 1 if successful or 0 if not
+ */
+int fvalue_test_utf8_string_copy_to_integer(
+     void )
+{
+	const uint8_t valid_source_string[]   = "4890";
+	const uint8_t invalid_source_string[] = "/:";
+	uint64_t integer_value                = 0;
+	libcerror_error_t *error              = NULL;
+	int result                            = 0;
+
+	/* Test a valid conversion
+	 */
+	result = libfvalue_utf8_string_copy_to_integer(
+	          valid_source_string,
+	          sizeof( valid_source_string ),
+	          &integer_value,
+	          64,
+	          LIBFVALUE_INTEGER_FORMAT_TYPE_DECIMAL | LIBFVALUE_INTEGER_FORMAT_FLAG_UNSIGNED,
+	          &error );
+
+	FVALUE_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 1 );
+
+	FVALUE_TEST_ASSERT_EQUAL_UINT64(
+	 "integer_value",
+	 integer_value,
+	 4890ul );
+
+	FVALUE_TEST_ASSERT_IS_NULL(
+	 "error",
+	 error );
+
+	/* Test an invalid conversion
+	 */
+	result = libfvalue_utf8_string_copy_to_integer(
+	          invalid_source_string,
+	          sizeof( valid_source_string ),
+	          &integer_value,
+	          64,
+	          LIBFVALUE_INTEGER_FORMAT_TYPE_DECIMAL | LIBFVALUE_INTEGER_FORMAT_FLAG_UNSIGNED,
+	          &error );
+
+	FVALUE_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 -1 );
+
+	FVALUE_TEST_ASSERT_IS_NOT_NULL(
+	 "error",
+	 error );
+
+	libcerror_error_free(
+	 &error );
+
+	return( 1 );
+
+on_error:
+	if( error != NULL )
+	{
+		libcerror_error_free(
+		 &error );
+	}
+	return( 0 );
+}
+
+/* Tests the libfvalue_utf16_string_copy_to_integer function
+ * Returns 1 if successful or 0 if not
+ */
+int fvalue_test_utf16_string_copy_to_integer(
+     void )
+{
+	const uint16_t valid_source_string[]   = {'4', '8', '9', '0', '\0'};
+	const uint16_t invalid_source_string[] = {'/', ':', '\0'};
+	uint64_t integer_value                 = 0;
+	libcerror_error_t *error               = NULL;
+	int result                             = 0;
+
+	/* Test a valid conversion
+	 */
+	result = libfvalue_utf16_string_copy_to_integer(
+	          valid_source_string,
+	          sizeof( valid_source_string ),
+	          &integer_value,
+	          64,
+	          LIBFVALUE_INTEGER_FORMAT_TYPE_DECIMAL | LIBFVALUE_INTEGER_FORMAT_FLAG_UNSIGNED,
+	          &error );
+
+	FVALUE_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 1 );
+
+	FVALUE_TEST_ASSERT_EQUAL_UINT64(
+	 "integer_value",
+	 integer_value,
+	 4890ul );
+
+	FVALUE_TEST_ASSERT_IS_NULL(
+	 "error",
+	 error );
+
+	/* Test an invalid conversion
+	 */
+	result = libfvalue_utf16_string_copy_to_integer(
+	          invalid_source_string,
+	          sizeof( valid_source_string ),
+	          &integer_value,
+	          64,
+	          LIBFVALUE_INTEGER_FORMAT_TYPE_DECIMAL | LIBFVALUE_INTEGER_FORMAT_FLAG_UNSIGNED,
+	          &error );
+
+	FVALUE_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 -1 );
+
+	FVALUE_TEST_ASSERT_IS_NOT_NULL(
+	 "error",
+	 error );
+
+	libcerror_error_free(
+	 &error );
+
+	return( 1 );
+
+on_error:
+	if( error != NULL )
+	{
+		libcerror_error_free(
+		 &error );
+	}
+	return( 0 );
+}
+
+/* Tests the libfvalue_utf32_string_copy_to_integer function
+ * Returns 1 if successful or 0 if not
+ */
+int fvalue_test_utf32_string_copy_to_integer(
+     void )
+{
+	const uint32_t valid_source_string[]   = {'4', '8', '9', '0', '\0'};
+	const uint32_t invalid_source_string[] = {'/', ':', '\0'};
+	uint64_t integer_value                 = 0;
+	libcerror_error_t *error               = NULL;
+	int result                             = 0;
+
+	/* Test a valid conversion
+	 */
+	result = libfvalue_utf32_string_copy_to_integer(
+	          valid_source_string,
+	          sizeof( valid_source_string ),
+	          &integer_value,
+	          64,
+	          LIBFVALUE_INTEGER_FORMAT_TYPE_DECIMAL | LIBFVALUE_INTEGER_FORMAT_FLAG_UNSIGNED,
+	          &error );
+
+	FVALUE_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 1 );
+
+	FVALUE_TEST_ASSERT_EQUAL_UINT64(
+	 "integer_value",
+	 integer_value,
+	 4890ul );
+
+	FVALUE_TEST_ASSERT_IS_NULL(
+	 "error",
+	 error );
+
+	/* Test an invalid conversion
+	 */
+	result = libfvalue_utf32_string_copy_to_integer(
+	          invalid_source_string,
+	          sizeof( valid_source_string ),
+	          &integer_value,
+	          64,
+	          LIBFVALUE_INTEGER_FORMAT_TYPE_DECIMAL | LIBFVALUE_INTEGER_FORMAT_FLAG_UNSIGNED,
+	          &error );
+
+	FVALUE_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 -1 );
+
+	FVALUE_TEST_ASSERT_IS_NOT_NULL(
+	 "error",
+	 error );
+
+	libcerror_error_free(
+	 &error );
+
+	return( 1 );
+
+on_error:
+	if( error != NULL )
+	{
+		libcerror_error_free(
+		 &error );
+	}
+	return( 0 );
+}
+
 #endif /* defined( __GNUC__ ) */
 
 /* The main program
@@ -466,6 +673,18 @@ int main(
 	/* TODO: add tests for libfvalue_integer_copy_from_utf32_string_with_index */
 
 	/* TODO: add tests for libfvalue_integer_copy_to_utf32_string_with_index */
+
+	FVALUE_TEST_RUN(
+	 "libfvalue_utf8_string_copy_to_integer",
+	 fvalue_test_utf8_string_copy_to_integer );
+
+	FVALUE_TEST_RUN(
+	 "libfvalue_utf16_string_copy_to_integer",
+	 fvalue_test_utf16_string_copy_to_integer );
+
+	FVALUE_TEST_RUN(
+	 "libfvalue_utf32_string_copy_to_integer",
+	 fvalue_test_utf32_string_copy_to_integer );
 
 #endif /* defined( __GNUC__ ) */
 


### PR DESCRIPTION
During decimal conversion in the check for if a character is an invalid
digit, the check would always evaluate to false. This allowed
*string_copy_to_integer() to always return a number on decimal
conversion and never fail regardless of sanity of input.

This was discovered during use of libfvde where it was trying to read a
hex plist value as a decimal and returning an incorrect number. Until
libfplist is updated to handle hex integer values libfvde will likely be
unable to deal with disks that it previously could.