### PR TITLE
Export more libfvalue functions

### DIFF
--- a/include/libfvalue.h.in
+++ b/include/libfvalue.h.in
@@ -210,18 +210,6 @@ int libfvalue_data_handle_set_value_entry_data(
      int encoding,
      libfvalue_error_t **error );
 
-/* Appends a value entry
- * Returns if successful or -1 on error
- */
-LIBFVALUE_EXTERN \
-int libfvalue_data_handle_append_value_entry_data(
-     libfvalue_data_handle_t *data_handle,
-     int *value_entry_index,
-     const uint8_t *value_entry_data,
-     size_t value_entry_data_size,
-     int encoding,
-     libfvalue_error_t **error );
-
 /* -------------------------------------------------------------------------
  * Integer functions
  * ------------------------------------------------------------------------- */
@@ -943,6 +931,14 @@ int libfvalue_value_get_number_of_value_entries(
      int *number_of_value_entries,
      libfvalue_error_t **error );
 
+LIBFVALUE_EXTERN \
+int libfvalue_value_get_entry(
+     libfvalue_value_t *value,
+     int value_entry_index,
+     size_t *entry_data_offset,
+     size_t *entry_data_size,
+     libcerror_error_t **error );
+
 /* Retrieves entry data
  * Returns 1 if successful, 0 if the value has no data or -1 on error
  */
@@ -967,6 +963,14 @@ int libfvalue_value_set_entry_data(
      int encoding,
      libfvalue_error_t **error );
 
+LIBFVALUE_EXTERN \
+int libfvalue_value_append_entry(
+     libfvalue_value_t *value,
+     int *value_entry_index,
+     size_t entry_data_offset,
+     size_t entry_data_size,
+     libcerror_error_t **error );
+
 /* Appends entry data
  * Returns 1 if successful or -1 on error
  */
@@ -978,6 +982,15 @@ int libfvalue_value_append_entry_data(
      size_t entry_data_size,
      int encoding,
      libfvalue_error_t **error );
+
+LIBFVALUE_EXTERN \
+int libfvalue_value_copy_entry_data(
+     libfvalue_value_t *value,
+     int value_entry_index,
+     uint8_t *entry_data,
+     size_t entry_data_size,
+     int *encoding,
+     libcerror_error_t **error );
 
 /* Copies the value data from a boolean value
  * Returns 1 if successful, 0 if value could not be set or -1 on error

--- a/libfvalue/libfvalue_data_handle.h
+++ b/libfvalue/libfvalue_data_handle.h
@@ -160,6 +160,18 @@ int libfvalue_data_handle_append_value_entry(
      size_t value_entry_size,
      libcerror_error_t **error );
 
+/* Appends a value entry
+ * Returns if successful or -1 on error
+ */
+LIBFVALUE_EXTERN \
+int libfvalue_data_handle_append_value_entry_data(
+     libfvalue_data_handle_t *data_handle,
+     int *value_entry_index,
+     const uint8_t *value_entry_data,
+     size_t value_entry_data_size,
+     int encoding,
+     libfvalue_error_t **error );
+
 LIBFVALUE_EXTERN \
 int libfvalue_data_handle_get_value_entry_data(
      libfvalue_data_handle_t *data_handle,

--- a/libfvalue/libfvalue_value.h
+++ b/libfvalue/libfvalue_value.h
@@ -462,25 +462,9 @@ int libfvalue_value_get_number_of_value_entries(
      libcerror_error_t **error );
 
 LIBFVALUE_EXTERN \
-int libfvalue_value_get_entry(
-     libfvalue_value_t *value,
-     int value_entry_index,
-     size_t *entry_data_offset,
-     size_t *entry_data_size,
-     libcerror_error_t **error );
-
-LIBFVALUE_EXTERN \
 int libfvalue_value_set_entry(
      libfvalue_value_t *value,
      int value_entry_index,
-     size_t entry_data_offset,
-     size_t entry_data_size,
-     libcerror_error_t **error );
-
-LIBFVALUE_EXTERN \
-int libfvalue_value_append_entry(
-     libfvalue_value_t *value,
-     int *value_entry_index,
      size_t entry_data_offset,
      size_t entry_data_size,
      libcerror_error_t **error );
@@ -510,15 +494,6 @@ int libfvalue_value_append_entry_data(
      const uint8_t *entry_data,
      size_t entry_data_size,
      int encoding,
-     libcerror_error_t **error );
-
-LIBFVALUE_EXTERN \
-int libfvalue_value_copy_entry_data(
-     libfvalue_value_t *value,
-     int value_entry_index,
-     uint8_t *entry_data,
-     size_t entry_data_size,
-     int *encoding,
      libcerror_error_t **error );
 
 /* Boolean value functions


### PR DESCRIPTION
```
libesedb_multi_value.c:338:13: error: implicit declaration of function 'libfvalue_value_get_entry'; did you mean 'libfvalue_value_get_data'? [-Wimplicit-function-declaration]
libesedb_multi_value.c:385:13: error: implicit declaration of function 'libfvalue_value_copy_entry_data'; did you mean 'libfvalue_value_set_entry_data'? [-Wimplicit-function-declaration]
libesedb_record.c:3813:29: error: implicit declaration of function 'libfvalue_value_append_entry'; did you mean 'libfvalue_value_append_entry_data'? [-Wimplicit-function-declaration]
libesedb_value_data_handle.c:175:29: error: implicit declaration of function 'libfvalue_data_handle_append_value_entry'; did you mean 'libfvalue_data_handle_append_value_entry_data'? [-Wimplicit-function-declaration]
```

``libfvalue_value_get_entry`` et al is used externally, by libesedb. Hence, it needs to be exported for DLLs to work correctly. This patch corrects that problem.

Fixes: #6