### PR TITLE
Export libfvalue_data_handle_append_value_entry

### DIFF
--- a/include/libfvalue.h.in
+++ b/include/libfvalue.h.in
@@ -214,6 +214,17 @@ int libfvalue_data_handle_set_value_entry_data(
  * Returns if successful or -1 on error
  */
 LIBFVALUE_EXTERN \
+int libfvalue_data_handle_append_value_entry(
+     libfvalue_data_handle_t *data_handle,
+     int *value_entry_index,
+     size_t value_entry_offset,
+     size_t value_entry_size,
+     libfvalue_error_t **error );
+
+/* Appends a value entry
+ * Returns if successful or -1 on error
+ */
+LIBFVALUE_EXTERN \
 int libfvalue_data_handle_append_value_entry_data(
      libfvalue_data_handle_t *data_handle,
      int *value_entry_index,


### PR DESCRIPTION
Commit cd1b553ed34b7504684cc7188d4c9edac340cf2e was supposed to export a function used by libesedb (mentioned in the commit message), but the patch did not include it.

libesedb fails to build still with libfvalue 20260522, and exporting the function is essential:

```
libesedb_value_data_handle.c:175:29: error: implicit declaration of
function 'libfvalue_data_handle_append_value_entry'; did you mean
'libfvalue_data_handle_append_value_entry_data'?
[-Wimplicit-function-declaration]
  175 | if( libfvalue_data_handle_append_value_entry(
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     libfvalue_data_handle_append_value_entry_data
```